### PR TITLE
Fix error message formatting

### DIFF
--- a/background.html
+++ b/background.html
@@ -173,7 +173,7 @@ function playUrl(url) {
     if (safari.extension.settings.host) {
         queueItem(url, function(result) {
                   if (result == 0) {
-                  alert("Error attempting to play item :" + url);
+                  alert("Error attempting to play item: " + url);
                   }
               });
     } else {


### PR DESCRIPTION
The colon in front of the URL made it look like it's part of the URL.
(Which would be malformed)
